### PR TITLE
Removed trailing ',' from META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -4,5 +4,5 @@
     "description" : "Calculate Damerau Levenshtein edit distance for strings.",
     "author"      : "ugexe",
     "depends"     : [],
-    "source-url"  : "git://github.com/ugexe/Perl6-Text--Levenshtein--Damerau.git",
+    "source-url"  : "git://github.com/ugexe/Perl6-Text--Levenshtein--Damerau.git"
 }


### PR DESCRIPTION
I notice that your module wasn't appearing in http://modules.perl6.org/

Removed trailing ',' to keep JSON load happy in perl6/modules.perl6

Module should hopefully appear in a few hours of accepting this pull request.
