### PR TITLE
Make ld, dld about two times faster

### DIFF
--- a/lib/Text/Levenshtein/Damerau.pm6
+++ b/lib/Text/Levenshtein/Damerau.pm6
@@ -56,15 +56,15 @@ sub dld (Str $source is copy, Str $target is copy, Int $max? is copy) is export 
         my Str $targetCh = $target.substr($i - 1, 1);
         @currentRow[0]   = $i;
 
-        my Int $start = [max] $i - $max - 1, 1;
-        my Int $end   = [min] $i + $max + 1, $sourceLength;
+        my Int $start = max $i - $max - 1, 1;
+        my Int $end   = min $i + $max + 1, $sourceLength;
 
         my Str $lastSourceCh = '';
         for $start..$end -> Int $j {
             my Str $sourceCh = $source.substr($j - 1, 1);
             my Int $cost     = $sourceCh eq $targetCh ?? 0 !! 1;
 
-            @currentRow[$j] = [min] 
+            @currentRow[$j] = min
                 @currentRow\[$j - 1] + 1, 
                 @previousRow[$j >= @previousRow.elems ?? *-1 !! $j] + 1,
                 @previousRow[$j - 1] + $cost,
@@ -106,13 +106,13 @@ sub ld (Str $source is copy, Str $target is copy, Int $max? is copy) is export {
 
     for 1..$targetLength -> Int $i {
         my Str $targetCh = $target.substr($i - 1, 1);
-        my Int $start = [max] $i - $max - 1, 1;
-        my Int $end   = [min] $i + $max + 1, $sourceLength;
+        my Int $start = max $i - $max - 1, 1;
+        my Int $end   = min $i + $max + 1, $sourceLength;
         @currentRow[0]   = $i;
 
         for $start..$end -> Int $j {
             my Str $sourceCh = $source.substr($j - 1, 1);
-            @currentRow[$j] = [min] 
+            @currentRow[$j] = min
                 @currentRow\[$j - 1] + 1,
                 @previousRow[$j    ] + 1,
                 @previousRow[$j - 1] + ($targetCh eq $sourceCh ?? 0 !! 1);


### PR DESCRIPTION
Use min or max instead of [min] or [max] since the former is faster.

Benchmark:
```
$ perl6 -e 'use Bench; use Text::Levenshtein::Damerau; my $b = Bench.new; $b.timethis(1000, sub { ld("abcd","vwxy") });'
          : 1.085 wallclock secs (1.108 usr 0.028 sys 1.136 cpu) @ 921.564/s (n=1000)

$ PERL6LIB=lib perl6 -e 'use Bench; use Text::Levenshtein::Damerau; my $b = Bench.new; $b.timethis(1000, sub { ld("abcd","vwxy") });'
          : 0.555 wallclock secs (0.564 usr 0.040 sys 0.604 cpu) @ 1800.199/s (n=1000)

$perl6 -e 'use Bench; use Text::Levenshtein::Damerau; my $b = Bench.new; $b.timethis(1000, sub { dld("abcd","vwxy") });'
          : 1.147 wallclock secs (1.172 usr 0.028 sys 1.200 cpu) @ 871.981/s (n=1000)

$ PERL6LIB=lib perl6 -e 'use Bench; use Text::Levenshtein::Damerau; my $b = Bench.new; $b.timethis(1000, sub { dld("abcd","vwxy") });'
          : 0.583 wallclock secs (0.620 usr 0.004 sys 0.624 cpu) @ 1714.969/s (n=1000)
```

Version:
```
$ perl6 --version
This is Rakudo version 2018.02.1-172-g34889bebc built on MoarVM version 2018.02-171-geee5be412
implementing Perl 6.c.
```